### PR TITLE
Removed assertion with warning on debugger access of unmapped memory

### DIFF
--- a/vp/src/core/common/debug_memory.cpp
+++ b/vp/src/core/common/debug_memory.cpp
@@ -46,7 +46,11 @@ std::string DebugMemoryInterface::read_memory(uint64_t start, unsigned nbytes) {
 	std::vector<uint8_t> buf(nbytes);  // NOTE: every element is zero-initialized by default
 
 	unsigned nbytes_read = _do_dbg_transaction(tlm::TLM_READ_COMMAND, start, buf.data(), buf.size());
-	assert(nbytes_read == nbytes && "not all bytes read");
+	if(nbytes_read < nbytes) {
+		std::cerr << "DebugMemoryInterface::read_memory: not all bytes read."
+					"Mostly this is caused by reading unmapped memory location."
+					<< std::endl;
+	}
 
 	std::stringstream stream;
 	stream << std::setfill('0') << std::hex;


### PR DESCRIPTION
Regards https://github.com/agra-uni-bremen/riscv-vp/issues/9